### PR TITLE
Add scotch library to EPIC's hpc-stack

### DIFF
--- a/build_stack.sh
+++ b/build_stack.sh
@@ -262,6 +262,7 @@ build_lib metplus
 # UFS 3rd party dependencies
 
 build_lib esmf
+build_lib scotch
 build_lib fms
 build_lib cmakemodules
 build_lib esma_cmake

--- a/config/config_hera.sh
+++ b/config/config_hera.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="intel/2022.1.2"
-export HPC_MPI="impi/2022.1.2"
-export HPC_PYTHON="miniconda3/4.12.0"
+export HPC_COMPILER="intel/18.0.5.274"
+export HPC_MPI="impi/2018.0.4"
+export HPC_PYTHON="miniconda3/4.6.14"
 
 # Build options
 export USE_SUDO=N
@@ -22,8 +22,6 @@ export VENVTYPE="condaenv"
 # Load these basic modules for Hera
 module purge
 module load cmake/3.20.1
-module load intel/2022.1.2
-module load impi/2022.1.2
 
 # Build FMS with AVX2 flags
 export STACK_fms_CFLAGS="-march=core-avx2"
@@ -31,7 +29,3 @@ export STACK_fms_FFLAGS="-march=core-avx2"
 
 # Miniconda3 URL on Hera
 export STACK_miniconda3_URL="http://anaconda.rdhpcs.noaa.gov"
-
-export SERIAL_CC=icc
-export SERIAL_CXX=icpc
-export SERIAL_FC=ifort

--- a/config/config_hera.sh
+++ b/config/config_hera.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Compiler/MPI combination
-export HPC_COMPILER="intel/18.0.5.274"
-export HPC_MPI="impi/2018.0.4"
-export HPC_PYTHON="miniconda3/4.6.14"
+export HPC_COMPILER="intel/2022.1.2"
+export HPC_MPI="impi/2022.1.2"
+export HPC_PYTHON="miniconda3/4.12.0"
 
 # Build options
 export USE_SUDO=N
@@ -22,6 +22,8 @@ export VENVTYPE="condaenv"
 # Load these basic modules for Hera
 module purge
 module load cmake/3.20.1
+module load intel/2022.1.2
+module load impi/2022.1.2
 
 # Build FMS with AVX2 flags
 export STACK_fms_CFLAGS="-march=core-avx2"
@@ -29,3 +31,7 @@ export STACK_fms_FFLAGS="-march=core-avx2"
 
 # Miniconda3 URL on Hera
 export STACK_miniconda3_URL="http://anaconda.rdhpcs.noaa.gov"
+
+export SERIAL_CC=icc
+export SERIAL_CXX=icpc
+export SERIAL_FC=ifort

--- a/libs/build_scotch.sh
+++ b/libs/build_scotch.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -eux
+
+name="scotch"
+version=${1:-${STACK_scotch_version}}
+
+# Hyphenated version used for install prefix
+compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
+mpi=$(echo $HPC_MPI | sed 's/\//-/g')
+
+if $MODULES; then
+  set +x
+  source $MODULESHOME/init/bash
+  module load hpc-$HPC_COMPILER
+  module load hpc-$HPC_MPI
+  module load cmake/3.20.1
+  module load netcdf/4.9.0
+  module load gnu
+  module list
+  set -x
+  
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
+  if [[ -d $prefix ]]; then
+      if [[ $OVERWRITE =~ [yYtT] ]]; then
+          echo "WARNING: $prefix EXISTS: OVERWRITING!"
+          $SUDO rm -rf $prefix
+      else
+          echo "WARNING: $prefix EXISTS, SKIPPING"
+          exit 0
+      fi
+  fi
+else
+  prefix=${SCOTCH_ROOT:-"/usr/local"}
+fi
+
+
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+
+software=$name-$version
+URL="https://gitlab.inria.fr/scotch/scotch/-/archive/v${version}/scotch-v${version}.tar.gz"
+[[ -f $software.tar.gz ]] || ( $WGET $URL )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
+cd scotch
+module purge
+module load cmake/3.20.1
+module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
+module load hpc/1.2.0
+module load hpc-intel/2022.1.2
+module load hpc-impi/2022.1.2
+module load netcdf/4.9.0
+module load gnu
+
+mkdir build
+cd build
+
+cmake VERBOSE=1 -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -DCMAKE_INSTALL_PREFIX=${SCOTCH_PREFIX}/install -DCMAKE_BUILD_TYPE=Release .. 2>&1 | tee cmake.out
+
+make VERBOSE=1 2>&1 | tee make.out
+make install 2>&1 | tee install.log
+make scotch 2>&1 | tee make_scotch.log
+make ptscotch 2>&1 | tee make_ptscotch.log

--- a/libs/build_scotch.sh
+++ b/libs/build_scotch.sh
@@ -3,12 +3,12 @@
 set -eux
 
 name="scotch"
-version_id=${1:-${STACK_scotch_version}}
+version=${1:-${STACK_scotch_version}}
 
 # Hyphenated version used for install prefix
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
-version=$(echo ${version_id} | sed 's/v//')
+id=$(echo $version | sed 's/v//')
 
 if $MODULES; then
   set +x
@@ -21,7 +21,7 @@ if $MODULES; then
   module list
   set -x
   
-  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$version"
+  prefix="${PREFIX:-"/opt/modules"}/$compiler/$mpi/$name/$id"
   if [[ -d $prefix ]]; then
       if [[ $OVERWRITE =~ [yYtT] ]]; then
           echo "WARNING: $prefix EXISTS: OVERWRITING!"
@@ -37,8 +37,8 @@ fi
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
-software=$name-${version_id}
-URL="https://gitlab.inria.fr/scotch/scotch/-/archive/${version_id}/scotch-${version_id}.tar.gz"
+software=$name-$version
+URL="https://gitlab.inria.fr/scotch/scotch/-/archive/$version/scotch-$version.tar.gz"
 [[ -f $software.tar.gz ]] || ( $WGET $URL )
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 
@@ -58,5 +58,5 @@ make ptscotch
 
 # generate modulefile from template
 [[ -z $mpi ]] && modpath=compiler || modpath=mpi
-$MODULES && update_modules $modpath $name $version
-echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log
+$MODULES && update_modules $modpath $name $id
+echo $name $id $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_scotch.sh
+++ b/libs/build_scotch.sh
@@ -9,6 +9,13 @@ version=${1:-${STACK_scotch_version}}
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
 
+cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+
+software=$name-"v"$version
+URL="https://gitlab.inria.fr/scotch/scotch/-/archive/v${version}/scotch-v${version}.tar.gz"
+[[ -f $software.tar.gz ]] || ( $WGET $URL )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+
 if $MODULES; then
   set +x
   source $MODULESHOME/init/bash
@@ -34,30 +41,22 @@ else
   prefix=${SCOTCH_ROOT:-"/usr/local"}
 fi
 
+tar -xvf $software.tar.gz; cd $software
+mkdir build; cd build
 
-cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
+#SCOTCH_PREFIX=${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}/$software
 
-software=$name-$version
-URL="https://gitlab.inria.fr/scotch/scotch/-/archive/v${version}/scotch-v${version}.tar.gz"
-[[ -f $software.tar.gz ]] || ( $WGET $URL )
-[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+#cmake VERBOSE=1 -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -DCMAKE_INSTALL_PREFIX=${SCOTCH_PREFIX}/install -DCMAKE_BUILD_TYPE=Release .. 2>&1 | tee cmake.out
 
-cd scotch
-module purge
-module load cmake/3.20.1
-module use /scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack
-module load hpc/1.2.0
-module load hpc-intel/2022.1.2
-module load hpc-impi/2022.1.2
-module load netcdf/4.9.0
-module load gnu
-
-mkdir build
-cd build
-
-cmake VERBOSE=1 -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -DCMAKE_INSTALL_PREFIX=${SCOTCH_PREFIX}/install -DCMAKE_BUILD_TYPE=Release .. 2>&1 | tee cmake.out
+cmake VERBOSE=1 -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_BUILD_TYPE=Release .. 2>&1 | tee cmake.out
 
 make VERBOSE=1 2>&1 | tee make.out
 make install 2>&1 | tee install.log
 make scotch 2>&1 | tee make_scotch.log
 make ptscotch 2>&1 | tee make_ptscotch.log
+
+
+# generate modulefile from template
+[[ -z $mpi ]] && modpath=compiler || modpath=mpi
+$MODULES && update_modules $modpath $name $version
+echo $name $version $URL >> ${HPC_STACK_ROOT}/hpc-stack-contents.log

--- a/libs/build_scotch.sh
+++ b/libs/build_scotch.sh
@@ -3,16 +3,19 @@
 set -eux
 
 name="scotch"
-version=${1:-${STACK_scotch_version}}
+version_id=${1:-${STACK_scotch_version}}
 
 # Hyphenated version used for install prefix
 compiler=$(echo $HPC_COMPILER | sed 's/\//-/g')
 mpi=$(echo $HPC_MPI | sed 's/\//-/g')
+version=$(echo ${version_id} | sed 's/v//')
 
 cd ${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}
 
-software=$name-"v"$version
-URL="https://gitlab.inria.fr/scotch/scotch/-/archive/v${version}/scotch-v${version}.tar.gz"
+#id=$(echo $version | sed ‘s/v//’)
+
+software=$name-${version_id}
+URL="https://gitlab.inria.fr/scotch/scotch/-/archive/${version_id}/scotch-${version_id}.tar.gz"
 [[ -f $software.tar.gz ]] || ( $WGET $URL )
 [[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
 
@@ -21,8 +24,8 @@ if $MODULES; then
   source $MODULESHOME/init/bash
   module load hpc-$HPC_COMPILER
   module load hpc-$HPC_MPI
-  module load cmake/3.20.1
-  module load netcdf/4.9.0
+  module load cmake
+  module load netcdf
   module load gnu
   module list
   set -x
@@ -46,7 +49,6 @@ mkdir build; cd build
 
 #SCOTCH_PREFIX=${HPC_STACK_ROOT}/${PKGDIR:-"pkg"}/$software
 
-#cmake VERBOSE=1 -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -DCMAKE_INSTALL_PREFIX=${SCOTCH_PREFIX}/install -DCMAKE_BUILD_TYPE=Release .. 2>&1 | tee cmake.out
 
 cmake VERBOSE=1 -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_BUILD_TYPE=Release .. 2>&1 | tee cmake.out
 

--- a/libs/build_scotch.sh
+++ b/libs/build_scotch.sh
@@ -45,7 +45,8 @@ URL="https://gitlab.inria.fr/scotch/scotch/-/archive/${version_id}/scotch-${vers
 [[ -f $software.tar.gz ]] && tar -xvf $software.tar.gz || ( echo "$software tarfile does not exist, ABORT!"; exit 1 )
 [[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
 
-mkdir build; cd build
+[[ -d build ]] && $SUDO rm -rf build
+mkdir -p build && cd build
 
 # Compile & Install Scotch/PTscotch
 cmake VERBOSE=1 -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -DCMAKE_INSTALL_PREFIX=$prefix -DCMAKE_BUILD_TYPE=Release ..

--- a/libs/build_scotch.sh
+++ b/libs/build_scotch.sh
@@ -15,8 +15,6 @@ if $MODULES; then
   source $MODULESHOME/init/bash
   module load hpc-$HPC_COMPILER
   module load hpc-$HPC_MPI
-  module load cmake
-  module load netcdf
   module load gnu
   module list
   set -x

--- a/modulefiles/compiler/compilerName/compilerVersion/scotch/scotch.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/scotch/scotch.lua
@@ -1,0 +1,34 @@
+help([[Scotch is a software package for graph and mesh/hypergraph partitioning,
+graph clustering, and sparse matrix ordering.]])
+
+local pkgName = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA = hierarchyA(pkgNameVer,1)
+local compNameVer = hierA[1]
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+depends_on("zlib")
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
+
+prepend_path("PATH", pathJoin(base,"bin"))
+prepend_path("MANPATH", pathJoin(base,"man"))
+prepend_path("LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("CPATH", pathJoin(base,"include"))
+prepend_path("CMAKE_PREFIX_PATH", base)
+
+setenv("scotch_ROOT", base)
+setenv("scotch_VERSION", pkgVersion)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: " .. pkgName .. " library")

--- a/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/scotch/scotch.lua
+++ b/modulefiles/mpi/compilerName/compilerVersion/mpiName/mpiVersion/scotch/scotch.lua
@@ -1,0 +1,36 @@
+help([[Scotch is a software package for graph and mesh/hypergraph partitioning,
+graph clustering, and sparse matrix ordering.]])
+
+local pkgName = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,2)
+local mpiNameVer   = hierA[1]
+local compNameVer  = hierA[2]
+local mpiNameVerD  = mpiNameVer:gsub("/","-")
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+depends_on("zlib")
+
+local opt = os.getenv("HPC_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,mpiNameVerD,pkgName,pkgVersion)
+
+prepend_path("PATH", pathJoin(base,"bin"))
+prepend_path("MANPATH", pathJoin(base,"man"))
+prepend_path("LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("CPATH", pathJoin(base,"include"))
+prepend_path("CMAKE_PREFIX_PATH", base)
+
+setenv("scotch_ROOT", base)
+setenv("scotch_VERSION", pkgVersion)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: " .. pkgName .. " library")


### PR DESCRIPTION
**Note: this PR mirrors NOAA-EMC/hpc-stack PR #504. It will serve as a temporary measure to get the scotch build capabilities into the hpc-stack for issue #501. we may end up using the EPIC fork to build an hpc-stack in the role.epic space on Hera that includes scotch for the WW3 group.** 

A request to support the scotch library (on at least Hera and Orion) came via https://github.com/NOAA-EMC/hpc-stack/issues/501. This PR includes the pertinent additions/adaptations to enable installation of scotch as part of the stack, including:

- a new build_scotch.sh script in /libs
- the addition of "build_lib scotch" to the ufs 3rd party apps. section of build_stack.sh
- scotch lua modulefile templates (serial/parallel)

Successful installation as a part of a test hpc-stack was performed on Hera w/ Intel-2022.1.2 compiler and MPI (src: /scratch1/NCEPDEV/stmp2/Cameron.Book/hpcs_work/src/scotchNsplenda , lib: /scratch1/NCEPDEV/stmp2/Cameron.Book/hpcs_work/libs/scotch). @natalie-perlin will follow with Orion testing, as I do not have access.

I have not added a scotch section to any of the stack/*yaml files simply because I am not sure which would be most relevant. Open to suggestions, or we can just leave the inclusion of the scotch section to users who actually want/need the library in their stack.

If the basic additions in this PR are deemed OK, we can go ahead and install scotch in the forthcoming, official, EPIC-maintained hpc-stack locations on Hera and Orion.

Note: I would like to recognize contributions from @natalie-perlin to this work.