### PR TITLE
Fix documentation build failures in release/public-v2.2.0 branch

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,28 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+build: 
+  os: ubuntu-20.04
+  tools: 
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+#  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinxcontrib-bibtex
 sphinx_rtd_theme
+docutils==0.16


### PR DESCRIPTION
A .readthedocs.yml file with build:os key is now required for documentation in ReadTheDocs , so all doc builds will fail until that is updated. See more information [here](https://blog.readthedocs.com/use-build-os-config/).
This PR adds the required .readthedocs.yaml file with required fields.
The requirements file was also updated. 
Docs successfully build on my fork: https://hpc-stack-gsp.readthedocs.io/en/text-release-updates/